### PR TITLE
fix: allow minimal scope in CLI commands

### DIFF
--- a/src/ocbs/cli.py
+++ b/src/ocbs/cli.py
@@ -23,7 +23,7 @@ def main(ctx, state_dir):
 
 
 @main.command()
-@click.option('--scope', type=click.Choice(['config', 'config+session', 'config+session+workspace']),
+@click.option('--scope', type=click.Choice(['minimal', 'config', 'config+session', 'config+session+workspace']),
               default='config', help='Backup scope')
 @click.option(
     '--source',
@@ -104,7 +104,7 @@ def status(ctx):
 
 
 @main.command()
-@click.option('--scope', type=click.Choice(['config', 'config+session', 'config+session+workspace']),
+@click.option('--scope', type=click.Choice(['minimal', 'config', 'config+session', 'config+session+workspace']),
               help='Filter by scope')
 @click.pass_context
 def list(ctx, scope):
@@ -124,7 +124,7 @@ def list(ctx, scope):
 
 
 @main.command()
-@click.option('--scope', type=click.Choice(['config', 'config+session', 'config+session+workspace']),
+@click.option('--scope', type=click.Choice(['minimal', 'config', 'config+session', 'config+session+workspace']),
               help='Cleanup specific scope')
 @click.pass_context
 def clean(ctx, scope):
@@ -161,7 +161,7 @@ def checkpoint(ctx, reason, serve):
 
 
 @main.command()
-@click.option('--scope', type=click.Choice(['config', 'config+session', 'config+session+workspace']),
+@click.option('--scope', type=click.Choice(['minimal', 'config', 'config+session', 'config+session+workspace']),
               default='config', help='Backup scope')
 @click.option('--verify', is_flag=True, help='Verify archive after creation')
 @click.option('--output', '-o', type=click.Path(exists=False, file_okay=False, dir_okay=True),

--- a/src/ocbs/cli.py
+++ b/src/ocbs/cli.py
@@ -10,6 +10,9 @@ import click
 from .core import BackupSource, BackupScope, OCBSCore
 from .serve import format_restore_message, start_restore_server
 
+# Shared scope choices to prevent drift
+SCOPE_CHOICES = ['minimal', 'config', 'config+session', 'config+session+workspace']
+
 
 @click.group()
 @click.option('--state-dir', type=click.Path(exists=False, file_okay=False, dir_okay=True),
@@ -23,7 +26,7 @@ def main(ctx, state_dir):
 
 
 @main.command()
-@click.option('--scope', type=click.Choice(['minimal', 'config', 'config+session', 'config+session+workspace']),
+@click.option('--scope', type=click.Choice(SCOPE_CHOICES),
               default='config', help='Backup scope')
 @click.option(
     '--source',
@@ -38,6 +41,13 @@ def backup(ctx, scope, source, reason):
     core = ctx.obj['core']
     scope_enum = BackupScope(scope)
     source_enum = BackupSource(source) if source else None
+    
+    # Guard: prevent minimal scope with native source until implemented
+    if scope == "minimal" and source == "native":
+        raise click.ClickException(
+            "Native backup does not yet support 'minimal' scope. "
+            "Use --source direct or choose a different scope."
+        )
     
     try:
         manifest = core.backup(scope_enum, reason, source=source_enum)
@@ -104,7 +114,7 @@ def status(ctx):
 
 
 @main.command()
-@click.option('--scope', type=click.Choice(['minimal', 'config', 'config+session', 'config+session+workspace']),
+@click.option('--scope', type=click.Choice(SCOPE_CHOICES),
               help='Filter by scope')
 @click.pass_context
 def list(ctx, scope):
@@ -124,7 +134,7 @@ def list(ctx, scope):
 
 
 @main.command()
-@click.option('--scope', type=click.Choice(['minimal', 'config', 'config+session', 'config+session+workspace']),
+@click.option('--scope', type=click.Choice(SCOPE_CHOICES),
               help='Cleanup specific scope')
 @click.pass_context
 def clean(ctx, scope):
@@ -161,7 +171,7 @@ def checkpoint(ctx, reason, serve):
 
 
 @main.command()
-@click.option('--scope', type=click.Choice(['minimal', 'config', 'config+session', 'config+session+workspace']),
+@click.option('--scope', type=click.Choice(SCOPE_CHOICES),
               default='config', help='Backup scope')
 @click.option('--verify', is_flag=True, help='Verify archive after creation')
 @click.option('--output', '-o', type=click.Path(exists=False, file_okay=False, dir_okay=True),
@@ -169,6 +179,13 @@ def checkpoint(ctx, reason, serve):
 def native_backup(scope, verify, output):
     """Run OpenClaw native backup to create a tar.gz archive."""
     import subprocess
+
+    # Fail fast until minimal scope semantics are implemented for native backup
+    if scope == "minimal":
+        raise click.ClickException(
+            "Native backup does not yet support 'minimal' scope. "
+            "Use 'config', 'config+session', or 'config+session+workspace'."
+        )
 
     args = ["openclaw", "backup", "create"]
 


### PR DESCRIPTION
Fixes an oversight where `--scope minimal` was defined in the core and docs but not permitted by the CLI's `click.Choice` array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded scope choices for backup/list/clean/checkpoint commands to offer finer-grained selection ("minimal", "config", "config+session", "config+session+workspace").

* **Bug Fixes / Validation**
  * Commands now prevent use of the "minimal" scope in contexts where it's unsupported (e.g., native source/backups) and present clear error messages when disallowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->